### PR TITLE
PR: Chore: remove `const hook = this` from counter example see: #17

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -57,9 +57,8 @@ Hooks.Items = {
 // See: hexdocs.pm/phoenix_live_view/js-interop.html#client-hooks-via-phx-hook
 Hooks.Counter = {
   mounted() {
-    const hook = this
     this.el.addEventListener("update-counter", e => {
-      hook.pushEventTo("#counter", "update-counter", {counter: e.detail.counter})
+      this.pushEventTo("#counter", "update-counter", {counter: e.detail.counter})
     })
   }
 }


### PR DESCRIPTION
@SimonLab as discussed in https://github.com/dwyl/learn-alpine.js/pull/17#pullrequestreview-1171933172 ✂️ 


https://user-images.githubusercontent.com/194400/200605130-22a4d3f5-b0a8-409b-aa82-d602ccc458a3.mov

